### PR TITLE
removes cpu/mem inputs

### DIFF
--- a/env/dev/README.md
+++ b/env/dev/README.md
@@ -42,7 +42,6 @@ $ terraform apply
 | certificate_arn | The ARN for the SSL certificate | string | - | yes |
 | container_name | The name of the container to run | string | - | yes |
 | container_port | The port the container will listen on, used for load balancer health check Best practice is that this value is higher than 1024 so the container processes isn't running at root. | string | - | yes |
-| cpu | How much of a virtual CPU (vCPU) to allocate for the container 256 is one-quarter of a vCPU | string | `256` | no |
 | default_backend_image | the default docker image to deploy with the infrastructure | string | `quay.io/turner/turner-defaultbackend:0.2.0` | no |
 | ecs_as_cpu_high_threshold_per | If the average CPU utilization over a minute rises to this threshold, the number of containers will be increased (but not above ecs_autoscale_max_instances). | string | `80` | no |
 | ecs_as_cpu_low_threshold_per | If the average CPU utilization over a minute drops to this threshold, the number of containers will be reduced (but not below ecs_autoscale_min_instances). | string | `20` | no |
@@ -59,7 +58,6 @@ $ terraform apply
 | lb_protocol | The load balancer protocol | string | `HTTP` | no |
 | logz_token | The auth token to use for sending logs to Logz.io | string | - | yes |
 | logz_url | The endpoint to use for sending logs to Logz.io | string | `https://listener.logz.io:8071` | no |
-| memory | How much memory to allocate to the container 512 is equal to 0.5 GB | string | `512` | no |
 | private_subnets | The private subnets, [minimum of 2][alb-docs], that are a part of the VPC(s) | string | - | yes |
 | public_subnets | The public subnets, [minimum of 2][alb-docs], that are a part of the VPC(s) | string | - | yes |
 | region | The AWS region to use for the dev environment's infrastructure Currently, Fargate is only available in `us-east-1`. | string | `us-east-1` | no |

--- a/env/dev/ecs.tf
+++ b/env/dev/ecs.tf
@@ -31,8 +31,8 @@ resource "aws_ecs_task_definition" "app" {
   family                   = "${var.app}-${var.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = "${var.cpu}"
-  memory                   = "${var.memory}"
+  cpu                      = "256"
+  memory                   = "512"
   execution_role_arn       = "${aws_iam_role.ecsTaskExecutionRole.arn}"
 
   # defined in role.tf

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -39,6 +39,16 @@ output "cicd_keys" {
   value = "terraform state show aws_iam_access_key.cicd_keys"
 }
 
+# Command to scale up cpu and memory
+output "scale_up" {
+  value = "fargate service update -h"
+}
+
+# Command to scale out the number of tasks (container replicas)
+output "scale_out" {
+  value = "fargate service scale -h"
+}
+
 # Command to set the AWS_PROFILE
 output "aws_profile" {
   value = "${var.aws_profile}"

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -73,21 +73,6 @@ variable "health_check_matcher" {
 # The name of the container to run
 variable "container_name" {}
 
-# The next two variable (cpu and memory) are very important to Fargate pricing
-# https://aws.amazon.com/fargate/pricing/
-
-# How much of a virtual CPU (vCPU) to allocate for the container
-# 256 is one-quarter of a vCPU
-variable "cpu" {
-  default = "256"
-}
-
-# How much memory to allocate to the container
-# 512 is equal to 0.5 GB
-variable "memory" {
-  default = "512"
-}
-
 # Network configuration
 
 # The VPC to use for the Fargate cluster


### PR DESCRIPTION
since they don't work after the first app task definition is deployed

they can be managed via the fargate cli after app deployment