### PR TITLE
adding secretsmanager support to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ that is needed.
 | [autoscale-perf.tf][edap] | Performance-based auto scaling | Yes |
 | [autoscale-time.tf][edat] | Time-based auto scaling | Yes |
 | [logs-logzio.tf][edll] | Ship container logs to logz.io | Yes |
+| [secretsmanager.tf][edsm] | Add a base secret to Secretsmanager | Yes |
 
 
 ## Usage
@@ -90,5 +91,6 @@ $ terraform apply
 [edap]: ./env/dev/autoscale-perf.tf
 [edat]: ./env/dev/autoscale-time.tf
 [edll]: ./env/dev/logs-logzio.tf
+[edsm]: ./env/dev/secretsmanager.tf
 [base]: ./base/README.md
 [env-dev]: ./env/dev/README.md

--- a/env/dev/README.md
+++ b/env/dev/README.md
@@ -20,6 +20,7 @@ The optional components can be removed by simply deleting the `.tf` file.
 | [autoscale-perf.tf][edap] | Performance-based auto scaling | Yes |
 | [autoscale-time.tf][edat] | Time-based auto scaling | Yes |
 | [logs-logzio.tf][edll] | Ship container logs to logz.io | Yes |
+| [secretsmanager.tf][edsm] | Add a base secret to Secretsmanager | Yes |
 
 
 ## Usage
@@ -97,5 +98,6 @@ $ terraform apply
 [edap]: autoscale-perf.tf
 [edat]: autoscale-time.tf
 [edll]: logs-logzio.tf
+[edsm]: secretsmanager.tf
 [alb-docs]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html
 [up]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html

--- a/env/dev/load-secrets.tpl
+++ b/env/dev/load-secrets.tpl
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+kv_to_json () {
+   echo -n '{'
+
+   WC=$(grep -v -e "^\s*$" hidden.env | wc -l)
+   count=1
+   while IFS='' read -r line; do
+     printf '"%s":"%s"' $(echo $line | sed 's/=/ /')
+     (( count++ ))
+     if [ $count -le $WC ]; then
+      echo -n ","
+     fi
+   done < <(grep -v -e "^\s*$" hidden.env)
+
+   echo '}'
+}
+
+AWS_PROFILE=${aws_profile}
+AWS_DEFAULT_REGION=${region}
+NAME=${secret}
+export AWS_PROFILE  AWS_DEFAULT_REGION
+
+if [ -e "./hidden.env" ]; then
+
+   FIND=$(aws secretsmanager describe-secret --secret-id $NAME)
+
+   if [[ $FIND =~ "can't find the specified secret" ]]; then
+     aws secretsmanager create-secret \
+        --name $NAME \
+        --description "$NAME" \
+        --secret-string $(kv_to_json)
+   elif [[ $FIND =~ "arn:aws:secretsmanager:" ]]; then
+     aws secretsmanager update-secret \
+        --secret-id $NAME \
+        --secret-string $(kv_to_json)
+   else
+      echo "I couldn't tell if the secret was there."
+   fi
+else
+  echo "No hidden.env."
+fi

--- a/env/dev/secretsmanager.tf
+++ b/env/dev/secretsmanager.tf
@@ -39,6 +39,6 @@ data "template_file" "load_secrets_tpl" {
 }
 
 resource "local_file" "load_secrets" {
-  filename = "load-secrets.sh"
+  filename = "upload-secrets.sh"
   content  = "${data.template_file.load_secrets_tpl.rendered}"
 }

--- a/env/dev/secretsmanager.tf
+++ b/env/dev/secretsmanager.tf
@@ -1,0 +1,44 @@
+# create the secretsmanager secret
+resource "aws_secretsmanager_secret" "sm_secret" {
+  name = "${var.app}-${var.environment}"
+  tags = "${var.tags}"
+}
+
+# secretsmanager assumabale roles and policies
+data "aws_iam_policy_document" "sm_policy_doc" {
+  statement = {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:Get*",
+      "secretsmanager:List*",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${var.app}-${var.environment}-*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "sm_policy" {
+  name   = "sm_role_policy"
+  role   = "${aws_iam_role.app_role.name}"
+  policy = "${data.aws_iam_policy_document.sm_policy_doc.json}"
+}
+
+# create the script to load the secrets into the secretsmanager secret
+data "template_file" "load_secrets_tpl" {
+  template = "${file("${path.module}/load-secrets.tpl")}"
+
+  vars {
+    region      = "${var.region}"
+    aws_profile = "${var.aws_profile}"
+    secret      = "${var.app}-${var.environment}"
+  }
+}
+
+resource "local_file" "load_secrets" {
+  filename = "load-secrets.sh"
+  content  = "${data.template_file.load_secrets_tpl.rendered}"
+}

--- a/env/dev/upload-secrets.tpl
+++ b/env/dev/upload-secrets.tpl
@@ -20,7 +20,8 @@ kv_to_json () {
 AWS_PROFILE=${aws_profile}
 AWS_DEFAULT_REGION=${region}
 NAME=${secret}
-export AWS_PROFILE  AWS_DEFAULT_REGION
+AWS_DEFAULT_OUTPUT=json
+export AWS_PROFILE AWS_DEFAULT_REGION NAME AWS_DEFAULT_OUTPUT
 
 if [ -e "./hidden.env" ]; then
 


### PR DESCRIPTION
Adding a basic secret to the template.  Also providing a templated bash script that will load hidden.env into that secret.

Minor instructions are still needed in the blog post to use this.