### PR TITLE
Moves cicd_keys output from main.tf to cicd.tf

### DIFF
--- a/env/dev/cicd.tf
+++ b/env/dev/cicd.tf
@@ -69,3 +69,8 @@ resource "aws_iam_user_policy" "cicd_user_policy" {
 data "aws_ecr_repository" "ecr" {
   name = "${var.app}"
 }
+
+# The AWS keys for the CICD user to use in a build system
+output "cicd_keys" {
+  value = "terraform state show aws_iam_access_key.cicd_keys"
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -34,11 +34,6 @@ output "deploy" {
   value = "fargate service deploy -f docker-compose.yml"
 }
 
-# The AWS keys for the CICD user to use in a build system
-output "cicd_keys" {
-  value = "terraform state show aws_iam_access_key.cicd_keys"
-}
-
 # Command to scale up cpu and memory
 output "scale_up" {
   value = "fargate service update -h"


### PR DESCRIPTION
This is to avoid a terraform error if someone opts-out and deletes `cicd.tf`.