### PR TITLE
moves docker_registry output from main to cicd

### DIFF
--- a/env/dev/cicd.tf
+++ b/env/dev/cicd.tf
@@ -74,3 +74,8 @@ data "aws_ecr_repository" "ecr" {
 output "cicd_keys" {
   value = "terraform state show aws_iam_access_key.cicd_keys"
 }
+
+# The URL for the docker image repo in ECR
+output "docker_registry" {
+  value = "${data.aws_ecr_repository.ecr.repository_url}"
+}

--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -19,11 +19,6 @@ output "lb_dns" {
   value = "${aws_alb.main.dns_name}"
 }
 
-# The URL for the docker image repo in ECR
-output "docker_registry" {
-  value = "${data.aws_ecr_repository.ecr.repository_url}"
-}
-
 # Command to view the status of the Fargate service
 output "status" {
   value = "fargate service info"


### PR DESCRIPTION
Fixes the following if you opt-out of `cicd.tf`.

```
Error: output 'docker_registry': unknown resource
'data.aws_ecr_repository.ecr' referenced in variable
data.aws_ecr_repository.ecr.repository_url
```