### PR TITLE
Update depends_on to refer to the targetgroup rather than the listener

### DIFF
--- a/env/dev/ecs.tf
+++ b/env/dev/ecs.tf
@@ -108,9 +108,9 @@ resource "aws_ecs_service" "app" {
     container_port   = "${var.container_port}"
   }
 
-  # workaround for https://github.com/hashicorp/terraform/issues/12634
+  # workaround for https://github.com/hashicorp/terraform/issues/12634 and https://github.com/terraform-providers/terraform-provider-aws/issues/3495
   depends_on = [
-    "aws_alb_listener.http",
+    "aws_alb_target_group.main",
   ]
 
   # # uncomment after first app deployment


### PR DESCRIPTION
By moving the dependency from the listener to the target group, users should be able to delete lb-http.tf without needing to update the dependency in ecs.tf.

The dependency is apparently no longer strictly required, because this merged PR https://github.com/terraform-providers/terraform-provider-aws/pull/3535 added retry logic for creating the ecs_service resource.

However, they still recommend a dependency to avoid a failed attempt.  From https://github.com/terraform-providers/terraform-provider-aws/issues/3495 :
> we'll continue to recommend the usage of depends_on in the aws_ecs_service resource pointing to the aws_lb_target_group, where possible.

Untested.