### PR TITLE
adds terraform required version

### DIFF
--- a/env/dev/main.tf
+++ b/env/dev/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 0.11.0"
+
   backend "s3" {
     region  = "us-east-1"
     profile = ""


### PR DESCRIPTION
Recent versions of the terraform vscode plugin have started showing this error.

```
terraform statement without a required_version attribute
```