### PR TITLE
Consumes the ecs event log stream and exposes in a dashboard

### DIFF
--- a/env/dev/ecs-event-stream.tf
+++ b/env/dev/ecs-event-stream.tf
@@ -104,13 +104,12 @@ resource "aws_cloudwatch_dashboard" "ecs-event-stream" {
       "width": 24,
       "height": 18,
       "properties": {
-        "query": "SOURCE '/aws/lambda/${var.app}-${var.environment}-ecs-event-stream' | fields @timestamp as time, detail.desiredStatus as desired, detail.lastStatus as latest, detail.containers.0.reason as reason, detail.taskDefinitionArn as task_definition\n| filter @type != \"START\" and @type != \"END\" and @type != \"REPORT\"\n| sort detail.updatedAt desc, detail.version desc\n| limit 100",
+        "query": "SOURCE '/aws/lambda/${var.app}-${var.environment}-ecs-event-stream' | fields @timestamp as time, detail.desiredStatus as desired, detail.lastStatus as latest, detail.stoppedReason as reason, detail.containers.0.reason as container_reason, detail.taskDefinitionArn as task_definition\n| filter @type != \"START\" and @type != \"END\" and @type != \"REPORT\"\n| sort detail.updatedAt desc, detail.version desc\n| limit 100",
         "region": "us-east-1",
         "title": "ECS Event Log"
       }
     }
   ]
 }
-
 EOF
 }

--- a/env/dev/ecs-event-stream.tf
+++ b/env/dev/ecs-event-stream.tf
@@ -2,8 +2,9 @@
  * ECS Event Stream
  * This component gives you full access to the ECS event logs
  * for your cluster by creating a cloudwatch event rule that listens for 
- * events for this cluster and calls a lambda that writes them to cloudwatch logs 
- * (which can be queried by other tools, like fargate cli).
+ * events for this cluster and calls a lambda that writes them to cloudwatch logs.
+ * It then adds a cloudwatch dashboard the displays the results of a
+ * logs insights query against the lambda logs
  */
 
 # cw event rule

--- a/env/dev/ecs-event-stream.tf
+++ b/env/dev/ecs-event-stream.tf
@@ -1,0 +1,91 @@
+/**
+ * ECS Event Stream
+ * This component gives you full access to the ECS event logs
+ * for your cluster by creating a cloudwatch event rule that listens for 
+ * events for this cluster and calls a lambda that writes them to cloudwatch logs 
+ * (which can be queried by other tools, like fargate cli).
+ */
+
+# cw event rule
+resource "aws_cloudwatch_event_rule" "ecs_event_stream" {
+  name        = "${var.app}-${var.environment}-ecs-event-stream"
+  description = "Passes ecs event logs for ${var.app}-${var.environment} to a lambda that writes them to cw logs"
+
+  event_pattern = <<PATTERN
+  {
+    "detail": {
+      "clusterArn": ["${aws_ecs_cluster.app.arn}"]
+    }
+  }
+  PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "ecs_event_stream" {
+  rule = "${aws_cloudwatch_event_rule.ecs_event_stream.name}"
+  arn  = "${aws_lambda_function.ecs_event_stream.arn}"
+}
+
+data "template_file" "lambda_source" {
+  template = <<EOF
+exports.handler = (event, context, callback) => {
+  console.log(JSON.stringify(event));
+}
+EOF
+}
+
+data "archive_file" "lambda_zip" {
+  type                    = "zip"
+  source_content          = "${data.template_file.lambda_source.rendered}"
+  source_content_filename = "index.js"
+  output_path             = "lambda-${var.app}.zip"
+}
+
+resource "aws_lambda_permission" "ecs_event_stream" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.ecs_event_stream.arn}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.ecs_event_stream.arn}"
+}
+
+resource "aws_lambda_function" "ecs_event_stream" {
+  function_name    = "${var.app}-${var.environment}-ecs-event-stream"
+  role             = "${aws_iam_role.ecs_event_stream.arn}"
+  filename         = "${data.archive_file.lambda_zip.output_path}"
+  source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
+  handler          = "index.handler"
+  runtime          = "nodejs8.10"
+  tags             = "${var.tags}"
+}
+
+resource "aws_lambda_alias" "ecs_event_stream" {
+  name             = "${aws_lambda_function.ecs_event_stream.function_name}"
+  description      = "latest"
+  function_name    = "${aws_lambda_function.ecs_event_stream.function_name}"
+  function_version = "$LATEST"
+}
+
+resource "aws_iam_role" "ecs_event_stream" {
+  name = "${aws_cloudwatch_event_rule.ecs_event_stream.name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_event_stream" {
+  role       = "${aws_iam_role.ecs_event_stream.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}

--- a/env/dev/fargate-create.yml
+++ b/env/dev/fargate-create.yml
@@ -35,7 +35,7 @@ prompts:
     filesToDeleteIfNo:
       - "secretsmanager.tf"
 
-  - question: "Would you like access to the full ECS event logs?"
+  - question: "Would you like an ECS event log dashboard?"
     default: "yes"
     filesToDeleteIfNo:
       - "ecs-event-stream.tf"      

--- a/env/dev/fargate-create.yml
+++ b/env/dev/fargate-create.yml
@@ -34,3 +34,8 @@ prompts:
     default: "no"
     filesToDeleteIfNo:
       - "secretsmanager.tf"
+
+  - question: "Would you like access to the full ECS event logs?"
+    default: "yes"
+    filesToDeleteIfNo:
+      - "ecs-event-stream.tf"      


### PR DESCRIPTION
This PR adds an optional component that exposes the ecs event log in a dashboard.  It does this with the following: 

- adds a cw event rule which listens for ecs events for the cluster 
- the event triggers a lambda which logs them
- adds a cw dashboard with a logs insights query that parses the events from the json in the logs 

Looks something like this
![image](https://user-images.githubusercontent.com/934927/49316112-e2733f00-f4bd-11e8-90a4-e7afc6c6f28e.png)

Note that this is similar to the events tab in the ecs service gui, but adds more detail including failure reasons (which are otherwise hard to track down since you have to find a particular task then click details).
