### PR TITLE
fixes for migration to terraform v0.12

### DIFF
--- a/env/dev/ecs.tf
+++ b/env/dev/ecs.tf
@@ -122,26 +122,26 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "app" {
-  name            = "${var.app}-${var.environment}"
-  cluster         = "${aws_ecs_cluster.app.id}"
-  launch_type     = "FARGATE"
+  name = "${var.app}-${var.environment}"
+  cluster = "${aws_ecs_cluster.app.id}"
+  launch_type = "FARGATE"
   task_definition = "${aws_ecs_task_definition.app.arn}"
-  desired_count   = "${var.replicas}"
+  desired_count = "${var.replicas}"
 
   network_configuration {
     security_groups = ["${aws_security_group.nsg_task.id}"]
-    subnets         = ["${split(",", var.private_subnets)}"]
+    subnets = "${split(",", var.private_subnets)}"
   }
 
   load_balancer {
     target_group_arn = "${aws_alb_target_group.main.id}"
-    container_name   = "${var.container_name}"
-    container_port   = "${var.container_port}"
+    container_name = "${var.container_name}"
+    container_port = "${var.container_port}"
   }
 
-  tags                    = "${var.tags}"
+  tags = "${var.tags}"
   enable_ecs_managed_tags = true
-  propagate_tags          = "SERVICE"
+  propagate_tags = "SERVICE"
 
   # workaround for https://github.com/hashicorp/terraform/issues/12634
   depends_on = [
@@ -157,7 +157,7 @@ resource "aws_ecs_service" "app" {
 
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "${var.app}-${var.environment}-ecs"
+  name = "${var.app}-${var.environment}-ecs"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_policy.json}"
 }
 
@@ -166,19 +166,19 @@ data "aws_iam_policy_document" "assume_role_policy" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type        = "Service"
+      type = "Service"
       identifiers = ["ecs-tasks.amazonaws.com"]
     }
   }
 }
 
 resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_policy" {
-  role       = "${aws_iam_role.ecsTaskExecutionRole.name}"
+  role = "${aws_iam_role.ecsTaskExecutionRole.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
-  name              = "/fargate/service/${var.app}-${var.environment}"
+  name = "/fargate/service/${var.app}-${var.environment}"
   retention_in_days = "14"
-  tags              = "${var.tags}"
+  tags = "${var.tags}"
 }

--- a/env/dev/variables.tf
+++ b/env/dev/variables.tf
@@ -45,3 +45,11 @@ variable "private_subnets" {}
 
 # The public subnets, minimum of 2, that are a part of the VPC(s)
 variable "public_subnets" {}
+
+# The CPU limit for this container definition
+variable "cpu" {}
+
+# The memory limit for this container definition
+variable "memory" {}
+# The ID of the hosted zone to contain this record. (Route53)
+variable "zone_id" {}


### PR DESCRIPTION
added variables and removed the square brackets from subnets in ecs.tf due to changes in v0.12 and list.

See: https://www.terraform.io/docs/configuration/functions/split.html