### PR TITLE
adds secrets-sidecar module

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ that is needed.
 | [autoscale-time.tf][edat] | Time-based auto scaling | Yes |
 | [logs-logzio.tf][edll] | Ship container logs to logz.io | Yes |
 | [secretsmanager.tf][edsm] | Add a Secrets Manager secret with a CMK KMS key. Also gives app role and ECS task definition role access to read secrets from Secrets Manager | Yes |
+| [secrets-sidecar.tf][ssc] | Adds a task definition configuration for deploying your app along with a sidecar container that writes your secrets manager secret to a file. Note that this is dependent upon opting in to `secretsmanager.tf`. | Yes |
 | [ssm-parameters.tf][ssm] | Add a CMK KMS key for use with SSM Parameter Store. Also gives ECS task definition role access to read secrets from parameter store. | Yes |
 | [ecs-event-stream.tf][ees] | Add an ECS event log dashboard | Yes |
 
@@ -141,3 +142,4 @@ $ fargate-create -f terraform.tfvars
 [ees]: ./env/dev/ecs-event-stream.tf
 [base]: ./base/README.md
 [env-dev]: ./env/dev/README.md
+[ssc]: secrets-sidecar.tf

--- a/env/dev/README.md
+++ b/env/dev/README.md
@@ -21,6 +21,7 @@ The optional components can be removed by simply deleting the `.tf` file.
 | [autoscale-time.tf][edat] | Time-based auto scaling | Yes |
 | [logs-logzio.tf][edll] | Ship container logs to logz.io | Yes |
 | [secretsmanager.tf][edsm] | Add a Secrets Manager secret with a CMK KMS key. Also gives app role and ECS task definition role access to read secrets from Secrets Manager | Yes |
+| [secrets-sidecar.tf][ssc] | Adds a task definition configuration for deploying your app along with a sidecar container that writes your secrets manager secret to a file. Note that this is dependent upon opting in to `secretsmanager.tf`. | Yes |
 | [ssm-parameters.tf][ssm] | Add a CMK KMS key for use with SSM Parameter Store. Also gives ECS task definition role access to read secrets from parameter store. | Yes |
 
 
@@ -72,6 +73,8 @@ $ terraform apply
 | scale_down_max_capacity | The maximum number of containers to scale down to. | string | `0` | no |
 | scale_down_min_capacity | The mimimum number of containers to scale down to. Set this and `scale_down_max_capacity` to 0 to turn off service on the `scale_down_cron` schedule. | string | `0` | no |
 | scale_up_cron | Default scale up at 7 am weekdays, this is UTC so it doesn't adjust to daylight savings https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html | string | `cron(0 11 ? * MON-FRI *)` | no |
+| secret_dir | directory where secret is written | string | `/var/secret` | yes |
+| secret_sidecar_image | sidecar container that writes the secret to a file accessible by app container | string | `quay.io/turner/secretsmanager-sidecar` | yes |
 | secrets_saml_users | The users (email addresses) from the saml role to give access | list | - | yes |
 | tags | Tags for the infrastructure | map | - | yes |
 | vpc | The VPC to use for the Fargate cluster | string | - | yes |
@@ -107,3 +110,4 @@ $ terraform apply
 [alb-docs]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html
 [up]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 [ssm]: ssm-parameters.tf
+[ssc]: secrets-sidecar.tf

--- a/env/dev/fargate-create.yml
+++ b/env/dev/fargate-create.yml
@@ -1,4 +1,3 @@
-
 # this file is used by fargate-create (https://github.com/turnerlabs/fargate-create)
 # if not using fargate-create, this file can be ignored/deleted
 
@@ -30,17 +29,22 @@ prompts:
       - "logs-logzio.tf"      
       - "logs-logzio.zip"
 
+  - question: "Would you like an ECS event log dashboard?"
+    default: "yes"
+    filesToDeleteIfNo:
+      - "ecs-event-stream.tf"
+
   - question: "Would you like to use Secrets Manager for secrets?"
     default: "no"
     filesToDeleteIfNo:
       - "secretsmanager.tf"
+  
+  - question: "Would you like a sidecar container that makes your secrets manager secret available as a file?"
+    default: "no"
+    filesToDeleteIfNo:
+      - "secrets-sidecar.tf"
 
   - question: "Would you like to use SSM Parameter Store for secrets?"
     default: "no"
     filesToDeleteIfNo:
       - "ssm-parameters.tf"
-
-  - question: "Would you like an ECS event log dashboard?"
-    default: "yes"
-    filesToDeleteIfNo:
-      - "ecs-event-stream.tf"      

--- a/env/dev/secrets-sidecar.tf
+++ b/env/dev/secrets-sidecar.tf
@@ -150,18 +150,18 @@ data "template_file" "secrets_sidecar_deploy" {
 #!/bin/bash
 set -e
 
-AWS_PROFILE=${aws_profile}
-AWS_DEFAULT_REGION=${region}
+AWS_PROFILE=$${aws_profile}
+AWS_DEFAULT_REGION=$${region}
 
 echo "backing up running container configuration"
-fargate task describe -t ${current_taskdefinition} > backup.yml
+fargate task describe -t $${current_taskdefinition} > backup.yml
 
 echo "deploying new sidecar configuration"
-fargate service deploy -r ${sidecar_revision}
+fargate service deploy -r $${sidecar_revision}
 
 echo "re-deploying app configuration"
 fargate service deploy -f backup.yml
-fargate service env set -e SECRET=${secret}
+fargate service env set -e SECRET=$${secret}
 EOF
 
   vars = {
@@ -182,4 +182,3 @@ resource "local_file" "secrets_sidecar" {
 output "deploy_secrets_sidecar" {
   value = "fargate service deploy --revision ${split(":", aws_ecs_task_definition.secrets_sidecar.arn)[6]}"
 }
-

--- a/env/dev/secrets-sidecar.tf
+++ b/env/dev/secrets-sidecar.tf
@@ -1,0 +1,151 @@
+/**
+ * This module adds a task definition configuration for deploying your app along with 
+ * a sidecar container that writes your secrets manager secret to an ephemeral file 
+ * that gets bind mounted into your app container. Note that this module is
+ * dependent upon opting in to the secretsmanager.tf module.
+ * 
+ * You can deploy this configuration using Fargate CLI:
+ * fargate service deploy -r x
+ * where "x" is the revision number that this module outputs (see terraform output)
+ *
+ * Note that if you deploy this configuration on top of your existing app,
+ * you will need to re-deploy your app (image and envvars) afterwards. 
+ * If using fargate-create CLI you can run ./deploy.sh
+ *
+ */
+
+variable "secret_dir" {
+  type        = string
+  default     = "/var/secret"
+  description = "directory where secret is written"
+}
+
+variable "secret_sidecar_image" {
+  type        = string
+  default     = "quay.io/turner/secretsmanager-sidecar"
+  description = "sidecar container that writes the secret to a file accessible by app container"
+}
+
+locals {
+  secret_file = "${var.secret_dir}/${aws_secretsmanager_secret.sm_secret.name}"
+  logs_group  = "/fargate/service/${var.app}-${var.environment}"
+}
+
+resource "aws_ecs_task_definition" "secrets_sidecar" {
+  family                   = "${var.app}-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
+  task_role_arn            = aws_iam_role.app_role.arn
+
+  volume {
+    name = "secret"
+  }
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "name": "${var.container_name}",
+    "image": "${var.default_backend_image}",
+    "essential": true,
+    "dependsOn": [
+      {
+        "containerName": "secrets_sidecar",
+        "condition": "SUCCESS"
+      }
+    ],
+    "portMappings": [
+      {
+        "protocol": "tcp",
+        "containerPort": ${var.container_port},
+        "hostPort": ${var.container_port}
+      }
+    ],
+    "environment": [
+      {
+        "name": "PORT",
+        "value": "${var.container_port}"
+      },
+      {
+        "name": "HEALTHCHECK",
+        "value": "${var.health_check}"
+      },
+      {
+        "name": "ENABLE_LOGGING",
+        "value": "false"
+      },
+      {
+        "name": "PRODUCT",
+        "value": "${var.app}"
+      },
+      {
+        "name": "ENVIRONMENT",
+        "value": "${var.environment}"
+      },
+      {
+        "name": "SECRET",
+        "value": "${local.secret_file}"
+      }
+    ],
+    "mountPoints": [
+      {
+        "readOnly": true,
+        "containerPath": "${var.secret_dir}",
+        "sourceVolume": "secret"
+      }
+    ],    
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${local.logs_group}",
+        "awslogs-region": "us-east-1",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  },
+  {
+    "name": "secrets_sidecar",
+    "image": "${var.secret_sidecar_image}",
+    "essential": false,
+    "environment": [
+      {
+        "name": "SECRET_ID",
+        "value": "${aws_secretsmanager_secret.sm_secret.arn}"
+      },
+      {
+        "name": "SECRET_FILE",
+        "value": "${local.secret_file}"
+      }
+    ],
+    "mountPoints": [
+      {
+        "readOnly": false,
+        "containerPath": "${var.secret_dir}",
+        "sourceVolume": "secret"
+      }
+    ],    
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${local.logs_group}",
+        "awslogs-region": "us-east-1",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  }  
+]
+DEFINITION
+
+  tags = var.tags
+
+  # avoid race condition: 
+  #"Too many concurrent attempts to create a new revision of the specified family"
+  depends_on = [aws_ecs_task_definition.app]
+}
+
+# command to deploy the secrets sidecar configuration
+output "deploy_secrets_sidecar" {
+  value = "fargate service deploy --revision ${split(":", aws_ecs_task_definition.secrets_sidecar.arn)[6]}"
+}

--- a/env/dev/secrets-sidecar.tf
+++ b/env/dev/secrets-sidecar.tf
@@ -52,7 +52,7 @@ resource "aws_ecs_task_definition" "secrets_sidecar" {
     "essential": true,
     "dependsOn": [
       {
-        "containerName": "secrets_sidecar",
+        "containerName": "secrets",
         "condition": "SUCCESS"
       }
     ],
@@ -106,7 +106,7 @@ resource "aws_ecs_task_definition" "secrets_sidecar" {
     }
   },
   {
-    "name": "secrets_sidecar",
+    "name": "secrets",
     "image": "${var.secret_sidecar_image}",
     "essential": false,
     "environment": [


### PR DESCRIPTION
This module adds a task definition configuration for deploying your app along with a sidecar container that writes your secrets manager secret to an ephemeral file that gets bind mounted into your app container. Note that this module is dependent upon opting in to the `secretsmanager.tf` module.

After `terraform apply` you can deploy this configuration via the generated script:
```
./secrets-sidecar-deploy.sh
 ```
