### PR TITLE
updates remote state module to v4.0.0

### DIFF
--- a/base/state.tf
+++ b/base/state.tf
@@ -10,7 +10,7 @@
 
 # s3 bucket for tf remote state
 module "tf_remote_state" {
-  source = "github.com/turnerlabs/terraform-remote-state?ref=v3.0.0"
+  source = "github.com/turnerlabs/terraform-remote-state?ref=v4.0.0"
 
   role        = var.saml_role
   application = var.app


### PR DESCRIPTION
This blocks public access as documented here: 
https://github.com/turnerlabs/terraform-remote-state/releases/tag/v4.0.0