### PR TITLE
Removing template provider

### DIFF
--- a/env/dev/ecs-event-stream.tf
+++ b/env/dev/ecs-event-stream.tf
@@ -28,18 +28,17 @@ resource "aws_cloudwatch_event_target" "ecs_event_stream" {
   arn  = aws_lambda_function.ecs_event_stream.arn
 }
 
-data "template_file" "lambda_source" {
-  template = <<EOF
+locals {
+  lambda_code = <<EOF
 exports.handler = (event, context, callback) => {
   console.log(JSON.stringify(event));
 }
 EOF
-
 }
 
 data "archive_file" "lambda_zip" {
   type                    = "zip"
-  source_content          = data.template_file.lambda_source.rendered
+  source_content          = local.lambda_code
   source_content_filename = "index.js"
   output_path             = "lambda-${var.app}.zip"
 }


### PR DESCRIPTION
The template provider is deprecated and doesn't have a Mac ARM version. Modern terraform has a built-in function is a better option.